### PR TITLE
feat: add font ligature setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
     - Modifies the `editor.fontFamily` and `terminal.integrated.fontFamily` settings respectively.
 - Adjust size of editor and terminal fonts.
     - Modifies the `editor.fontSize` and `terminal.integrated.fontSize` respectively.
+- Automatically update `editor.fontLigature` for different fonts.
+    - In `settings.json`, set `font-switcher.fontLigatures` to an object with the font family as the key and the ligature setting as the value. For example: `{ "Fira Code": "'ss01'", "JetBrains Mono": "'ss19'", __default__: false }`. `__default__` is used when the font family is not found in the object.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,17 @@
         "command": "font-switcher.setTerminalFontSize",
         "title": "Terminal Font Size"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Font Switcher",
+      "properties": {
+        "font-switcher.fontLigatures": {
+          "type": "object",
+          "default": { "__default__": false },
+          "description": "Font liguature settings to apply for specific fonts."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,7 @@
 "use strict";
 import { workspace, WorkspaceConfiguration } from "vscode";
 
-export type Target = "Editor" | "Terminal";
+export type Target = "Editor" | "Terminal" | "FontLigatures";
 
 // Parse a font string into an array.
 export function parseFontString(fontString: String): string[] {
@@ -13,5 +13,11 @@ export function getConfig(target: Target): WorkspaceConfiguration {
     if (target === "Editor") {
         return workspace.getConfiguration("editor");
     }
-    return workspace.getConfiguration("terminal.integrated");
+    if (target === "Terminal") {
+        return workspace.getConfiguration("terminal.integrated");
+    }
+    if (target === "FontLigatures") {
+        return workspace.getConfiguration("font-switcher.fontLigatures");
+    }
+    return workspace.getConfiguration();
 }


### PR DESCRIPTION
This adds a feature requested in #20. That I've also been wanting for awhile.

Users can set the `font-switcher.fontLigatures` in their user settings JSON file. Whenever they switch fonts using the Quick Pick menu, the extension will automatically update the top-level `editor.fontLigatures` setting.

This allows users to use different font variants for different fonts. See README additions for details.

Feel free to modify to your own liking, and thanks for publishing this in the first place!